### PR TITLE
Avoid division by zero

### DIFF
--- a/cytoscape-dagre.js
+++ b/cytoscape-dagre.js
@@ -148,7 +148,7 @@
       var constrainPos = function( p ){
         if( options.boundingBox ){
           var xPct = (p.x - dagreBB.x1) / dagreBB.w;
-          var yPct = (p.y - dagreBB.y1) / dagreBB.h;
+          var yPct = dagreBB.h === 0 ? 0 : (p.y - dagreBB.y1) / dagreBB.h;
 
           return {
             x: bb.x1 + xPct * bb.w,


### PR DESCRIPTION
If all nodes are unconnected, `dagreBB.h == 0`, leading to nodes with `NaN` as their `y` coordinate.