### PR TITLE
triangle edge arrows cytoscapejs > 2.7

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -68,7 +68,8 @@
 								'width': 4,
 								'target-arrow-shape': 'triangle',
 								'line-color': '#9dbaea',
-								'target-arrow-color': '#9dbaea'
+								'target-arrow-color': '#9dbaea',
+                                'curve-style': 'bezier'
 							}
 						}
 					],


### PR DESCRIPTION
Hi! 

The demo did not show triangle edge arrows (like the thumbnail image in the [demos section](http://js.cytoscape.org/) after the [cytoscape.js 2.7 update](https://github.com/cytoscape/cytoscape.js/issues/1199). I've updated the demo with triangle arrows.

Bjørn