### PR TITLE
add spacingFactor option

### DIFF
--- a/cytoscape-dagre.js
+++ b/cytoscape-dagre.js
@@ -41,6 +41,7 @@ SOFTWARE.
       // general layout options
       fit: true, // whether to fit to viewport
       padding: 30, // fit padding
+      spacingFactor: undefined, // Applies a multiplicative factor (>0) to expand or compress the overall area that the nodes take up
       animate: false, // whether to transition the node positions
       animationDuration: 500, // duration of animation in ms if enabled
       animationEasing: undefined, // easing of animation if enabled


### PR DESCRIPTION
Accompanies [PR #1673](https://github.com/cytoscape/cytoscape.js/pull/1673) in cytoscape.js (for 3.1 release).
New feature (does not break compatibility with old configurations) should bump version to 1.4.