### PR TITLE
Add onlyVisible option to ignore hidden elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ var defaults = {
   rankSep: undefined, // the separation between adjacent nodes in the same rank
   rankDir: undefined, // 'TB' for top to bottom flow, 'LR' for left to right,
   ranker: undefined, // Type of algorithm to assign a rank to each node in the input graph. Possible values: 'network-simplex', 'tight-tree' or 'longest-path'
+  onlyVisible: false, // ignore hidden elements in the layout calculation
   minLen: function( edge ){ return 1; }, // number of ranks to keep between the source and target of the edge
   edgeWeight: function( edge ){ return 1; }, // higher weight edges are generally made shorter and straighter than lower weight edges
 

--- a/cytoscape-dagre.js
+++ b/cytoscape-dagre.js
@@ -153,6 +153,11 @@ DagreLayout.prototype.run = function () {
 
   // add nodes to dagre
   var nodes = eles.nodes();
+  if (options.onlyVisible) {
+    nodes = nodes.filter(function (x) {
+      return x.visible();
+    });
+  }
   for (var i = 0; i < nodes.length; i++) {
     var node = nodes[i];
     var nbb = node.layoutDimensions(options);
@@ -177,6 +182,9 @@ DagreLayout.prototype.run = function () {
 
   // add edges to dagre
   var edges = eles.edges().stdFilter(function (edge) {
+    if (options.onlyVisible && (edge.source().visible() || edge.target().visible())) {
+      return false;
+    }
     return !edge.source().isParent() && !edge.target().isParent(); // dagre can't handle edges on compound nodes
   });
   for (var _i2 = 0; _i2 < edges.length; _i2++) {
@@ -288,6 +296,7 @@ var defaults = {
   rankDir: undefined, // 'TB' for top to bottom flow, 'LR' for left to right,
   ranker: undefined, // Type of algorithm to assigns a rank to each node in the input graph.
   // Possible values: network-simplex, tight-tree or longest-path
+  onlyVisible: false, // ignore hidden elements in the layout calculation
   minLen: function minLen(edge) {
     return 1;
   }, // number of ranks to keep between the source and target of the edge

--- a/demo.only-visible.html
+++ b/demo.only-visible.html
@@ -1,0 +1,123 @@
+<!DOCTYPE>
+
+<html>
+
+  <head>
+    <title>cytoscape-dagre.js demo</title>
+
+    <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1, maximum-scale=1">
+
+    <script src="https://unpkg.com/cytoscape/dist/cytoscape.min.js"></script>
+
+    <!-- for testing with local version of cytoscape.js -->
+    <!--<script src="../cytoscape.js/build/cytoscape.js"></script>-->
+
+    <script src="https://unpkg.com/dagre@0.7.4/dist/dagre.js"></script>
+    <script src="cytoscape-dagre.js"></script>
+
+    <style>
+      body {
+        font-family: helvetica;
+        font-size: 14px;
+      }
+
+      #cy {
+        width: 100%;
+        height: 100%;
+        position: absolute;
+        left: 0;
+        top: 0;
+        z-index: 999;
+      }
+
+      h1 {
+        opacity: 0.5;
+        font-size: 1em;
+      }
+    </style>
+
+    <script>
+      window.addEventListener('DOMContentLoaded', function(){
+
+        var cy = window.cy = cytoscape({
+          container: document.getElementById('cy'),
+
+          boxSelectionEnabled: false,
+          autounselectify: true,
+
+          layout: {
+            name: 'dagre',
+            onlyVisible: true
+          },
+
+          style: [
+            {
+              selector: 'node',
+              style: {
+                'background-color': '#11479e',
+                'content': 'data(id)'
+              }
+            },
+
+            {
+              selector: 'edge',
+              style: {
+                'width': 4,
+                'target-arrow-shape': 'triangle',
+                'line-color': '#9dbaea',
+                'target-arrow-color': '#9dbaea',
+                'curve-style': 'bezier'
+              }
+            }
+          ],
+
+          elements: {
+            nodes: [
+              { data: { id: 'n0' } },
+              { data: { id: 'n1' } },
+              { data: { id: 'n2' } },
+              { data: { id: 'n3' } },
+              { data: { id: 'n4' } },
+              { data: { id: 'n5' } },
+              { data: { id: 'n6' } },
+              { data: { id: 'n7' } },
+              { data: { id: 'n8' } },
+              { data: { id: 'n9' } },
+              { data: { id: 'n10' } },
+              { data: { id: 'n11' } },
+              { data: { id: 'n12' } },
+              { data: { id: 'n13' } },
+              { data: { id: 'n14' } },
+              { data: { id: 'n15' }, style: {display:'none'} },
+              { data: { id: 'n16' } }
+            ],
+            edges: [
+              { data: { source: 'n0', target: 'n1' } },
+              { data: { source: 'n1', target: 'n2' } },
+              { data: { source: 'n1', target: 'n3' } },
+              { data: { source: 'n4', target: 'n5' } },
+              { data: { source: 'n4', target: 'n6' } },
+              { data: { source: 'n6', target: 'n7' } },
+              { data: { source: 'n6', target: 'n8' } },
+              { data: { source: 'n8', target: 'n9' } },
+              { data: { source: 'n8', target: 'n10' } },
+              { data: { source: 'n11', target: 'n12' } },
+              { data: { source: 'n12', target: 'n13' } },
+              { data: { source: 'n13', target: 'n14' } },
+              { data: { source: 'n13', target: 'n15' } },
+            ]
+          }
+        });
+
+      });
+    </script>
+  </head>
+
+  <body>
+    <h1>cytoscape-dagre demo</h1>
+
+    <div id="cy"></div>
+
+  </body>
+
+</html>

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -6,6 +6,7 @@ let defaults = {
   rankDir: undefined, // 'TB' for top to bottom flow, 'LR' for left to right,
   ranker:  undefined, // Type of algorithm to assigns a rank to each node in the input graph.
                       // Possible values: network-simplex, tight-tree or longest-path
+  onlyVisible: false, // ignore hidden elements in the layout calculation
   minLen: function( edge ){ return 1; }, // number of ranks to keep between the source and target of the edge
   edgeWeight: function( edge ){ return 1; }, // higher weight edges are generally made shorter and straighter than lower weight edges
 

--- a/src/layout.js
+++ b/src/layout.js
@@ -52,6 +52,9 @@ DagreLayout.prototype.run = function(){
 
   // add nodes to dagre
   let nodes = eles.nodes();
+   if(options.onlyVisible) {
+     nodes = nodes.filter(x => x.visible());
+   }
   for( let i = 0; i < nodes.length; i++ ){
     let node = nodes[i];
     let nbb = node.layoutDimensions( options );
@@ -76,7 +79,9 @@ DagreLayout.prototype.run = function(){
 
   // add edges to dagre
   let edges = eles.edges().stdFilter(function( edge ){
-    return !edge.source().isParent() && !edge.target().isParent(); // dagre can't handle edges on compound nodes
+    const isCompound = edge.source().isParent() && edge.target().isParent();  // dagre can't handle edges on compound nodes
+    const bothVisible = edge.source().visible() && edge.target().visible();
+    return !isCompound && (!options.onlyVisible || bothVisible) ;
   });
   for( let i = 0; i < edges.length; i++ ){
     let edge = edges[i];


### PR DESCRIPTION
In the default configuration even hidden nodes use space. This might
result in an unintuitive layout. Space is reserved for those
nodes, but no content is displayed.

According to
 http://js.cytoscape.org/#style/visibility
elements with the property display:none do not use space and
elements should not use space and not be connected.

However, the cytoscape API
 http://js.cytoscape.org/#ele.visible
provides a 'hide' method that sets display to 'none' and a
'hidden' function that is just the oposit of the 'visible' function.

Thus a new option 'onlyVisible' was added that the user can define,
if invisible elements should use space.