### PR TITLE
Workaround for missing window in web worker

### DIFF
--- a/cytoscape-dagre.js
+++ b/cytoscape-dagre.js
@@ -7,7 +7,7 @@
 		exports["cytoscapeDagre"] = factory(require("dagre"));
 	else
 		root["cytoscapeDagre"] = factory(root["dagre"]);
-})(window, function(__WEBPACK_EXTERNAL_MODULE__4__) {
+})(this, function(__WEBPACK_EXTERNAL_MODULE__4__) {
 return /******/ (function(modules) { // webpackBootstrap
 /******/ 	// The module cache
 /******/ 	var installedModules = {};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,7 +15,8 @@ let config = {
     path: path.join( __dirname ),
     filename: pkg.name + '.js',
     library: camelcase( pkg.name ),
-    libraryTarget: 'umd'
+    libraryTarget: 'umd',
+    globalObject: "this"
   },
   module: {
     rules: [


### PR DESCRIPTION
Adds a simple workaround to make this extension compatible with web workers.
See also https://github.com/webpack/webpack/issues/6642