### PR TITLE
Align and acyclicer options

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ var defaults = {
   edgeSep: undefined, // the separation between adjacent edges in the same rank
   rankSep: undefined, // the separation between each rank in the layout
   rankDir: undefined, // 'TB' for top to bottom flow, 'LR' for left to right,
+  align: undefined,  // alignment for rank nodes. Can be 'UL', 'UR', 'DL', or 'DR', where U = up, D = down, L = left, and R = right
+  acyclicer: undefined, // If set to 'greedy', uses a greedy heuristic for finding a feedback arc set for a graph.
+                        // A feedback arc set is a set of edges that can be removed to make a graph acyclic.
   ranker: undefined, // Type of algorithm to assign a rank to each node in the input graph. Possible values: 'network-simplex', 'tight-tree' or 'longest-path'
   minLen: function( edge ){ return 1; }, // number of ranks to keep between the source and target of the edge
   edgeWeight: function( edge ){ return 1; }, // higher weight edges are generally made shorter and straighter than lower weight edges

--- a/cytoscape-dagre.js
+++ b/cytoscape-dagre.js
@@ -190,7 +190,9 @@ DagreLayout.prototype.run = function () {
   setGObj('edgesep', options.edgeSep);
   setGObj('ranksep', options.rankSep);
   setGObj('rankdir', options.rankDir);
+  setGObj('align', options.align);
   setGObj('ranker', options.ranker);
+  setGObj('acyclicer', options.acyclicer);
   g.setGraph(gObj);
   g.setDefaultEdgeLabel(function () {
     return {};
@@ -304,6 +306,8 @@ var defaults = {
   rankSep: undefined,
   // the separation between adjacent nodes in the same rank
   rankDir: undefined,
+  // alignment for rank nodes. Can be 'UL', 'UR', 'DL', or 'DR', where U = up, D = down, L = left, and R = right
+  align: undefined,
   // 'TB' for top to bottom flow, 'LR' for left to right,
   ranker: undefined,
   // Type of algorithm to assigns a rank to each node in the input graph.

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -4,6 +4,9 @@ let defaults = {
   edgeSep: undefined, // the separation between adjacent edges in the same rank
   rankSep: undefined, // the separation between adjacent nodes in the same rank
   rankDir: undefined, // 'TB' for top to bottom flow, 'LR' for left to right,
+  align: undefined,  // alignment for rank nodes. Can be 'UL', 'UR', 'DL', or 'DR', where U = up, D = down, L = left, and R = right
+  acyclicer: undefined, // If set to 'greedy', uses a greedy heuristic for finding a feedback arc set for a graph.
+                        // A feedback arc set is a set of edges that can be removed to make a graph acyclic.
   ranker:  undefined, // Type of algorithm to assigns a rank to each node in the input graph.
                       // Possible values: network-simplex, tight-tree or longest-path
   minLen: function( edge ){ return 1; }, // number of ranks to keep between the source and target of the edge

--- a/src/layout.js
+++ b/src/layout.js
@@ -43,7 +43,9 @@ DagreLayout.prototype.run = function(){
   setGObj( 'edgesep', options.edgeSep );
   setGObj( 'ranksep', options.rankSep );
   setGObj( 'rankdir', options.rankDir );
+  setGObj( 'align', options.align);
   setGObj( 'ranker', options.ranker );
+  setGObj( 'acyclicer', options.acyclicer);
 
   g.setGraph( gObj );
 


### PR DESCRIPTION
Resolves #83.

- Added two missing dagre layout options: align, acyclicer
- Readme documentation about default values is also added.