### PR TITLE
Add ability to sort nodes and edges

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ var defaults = {
   boundingBox: undefined, // constrain layout bounds; { x1, y1, x2, y2 } or { x1, y1, w, h }
   transform: function( node, pos ){ return pos; }, // a function that applies a transform to the final node position
   ready: function(){}, // on layoutready
-  sort: undefined, // cytoscape sort function to sort the nodes and edges
+  sort: undefined, // a sorting function to order the nodes and edges; e.g. function(a, b){ return a.data('weight') - b.data('weight') }
   stop: function(){} // on layoutstop
 };
 ```

--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ var defaults = {
   transform: function( node, pos ){ return pos; }, // a function that applies a transform to the final node position
   ready: function(){}, // on layoutready
   sort: undefined, // a sorting function to order the nodes and edges; e.g. function(a, b){ return a.data('weight') - b.data('weight') }
+                   // because cytoscape dagre creates a directed graph, and directed graphs use the node order as a tie breaker when
+                   // defining the topology of a graph, this sort function can help ensure the correct order of the nodes/edges.
+                   // this feature is most useful when adding and removing the same nodes and edges multiple times in a graph.
   stop: function(){} // on layoutstop
 };
 ```

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ var defaults = {
   boundingBox: undefined, // constrain layout bounds; { x1, y1, x2, y2 } or { x1, y1, w, h }
   transform: function( node, pos ){ return pos; }, // a function that applies a transform to the final node position
   ready: function(){}, // on layoutready
+  sort: undefined, // cytoscape sort function to sort the nodes and edges
   stop: function(){} // on layoutstop
 };
 ```

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -24,6 +24,7 @@ let defaults = {
   boundingBox: undefined, // constrain layout bounds; { x1, y1, x2, y2 } or { x1, y1, w, h }
   transform: function( node, pos ){ return pos; }, // a function that applies a transform to the final node position
   ready: function(){}, // on layoutready
+  sort: undefined, // cytoscape sort function to sort the nodes and edges
   stop: function(){} // on layoutstop
 };
 

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -25,6 +25,9 @@ let defaults = {
   transform: function( node, pos ){ return pos; }, // a function that applies a transform to the final node position
   ready: function(){}, // on layoutready
   sort: undefined, // a sorting function to order the nodes and edges; e.g. function(a, b){ return a.data('weight') - b.data('weight') }
+                   // because cytoscape dagre creates a directed graph, and directed graphs use the node order as a tie breaker when
+                   // defining the topology of a graph, this sort function can help ensure the correct order of the nodes/edges.
+                   // this feature is most useful when adding and removing the same nodes and edges multiple times in a graph.
   stop: function(){} // on layoutstop
 };
 

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -24,7 +24,7 @@ let defaults = {
   boundingBox: undefined, // constrain layout bounds; { x1, y1, x2, y2 } or { x1, y1, w, h }
   transform: function( node, pos ){ return pos; }, // a function that applies a transform to the final node position
   ready: function(){}, // on layoutready
-  sort: undefined, // cytoscape sort function to sort the nodes and edges
+  sort: undefined, // a sorting function to order the nodes and edges; e.g. function(a, b){ return a.data('weight') - b.data('weight') }
   stop: function(){} // on layoutstop
 };
 

--- a/src/layout.js
+++ b/src/layout.js
@@ -54,6 +54,11 @@ DagreLayout.prototype.run = function(){
 
   // add nodes to dagre
   let nodes = eles.nodes();
+
+  if ( isFunction(options.sort) ) {
+    nodes = nodes.sort( options.sort );
+  }
+
   for( let i = 0; i < nodes.length; i++ ){
     let node = nodes[i];
     let nbb = node.layoutDimensions( options );
@@ -80,6 +85,11 @@ DagreLayout.prototype.run = function(){
   let edges = eles.edges().stdFilter(function( edge ){
     return !edge.source().isParent() && !edge.target().isParent(); // dagre can't handle edges on compound nodes
   });
+
+  if ( isFunction(options.sort) ) {
+    edges = edges.sort( options.sort );
+  }
+
   for( let i = 0; i < edges.length; i++ ){
     let edge = edges[i];
 


### PR DESCRIPTION
Some of the default layouts in cytoscape have a `sort` option (or some variation of it) that lets you sort the nodes/edges so the resulting graph is predictable if you're adding/removing nodes.

examples layouts with sort:
https://js.cytoscape.org/#layouts/grid
https://js.cytoscape.org/#layouts/circle
https://js.cytoscape.org/#layouts/breadthfirst

Without this, the graph will have a different outcome if several nodes/edges are added, then some middle nodes/edges are removed, and then those same removed nodes/edges are added back.