### PR TITLE
proposal to include license headers in all source files.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 
 
-Copyright (c) 2016-2018, 2020, 2022, The Cytoscape Consortium.
+Copyright (c) 2016-2018, 2020, 2022, 2026 The Cytoscape Consortium.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the “Software”), to deal in

--- a/src/assign.js
+++ b/src/assign.js
@@ -1,4 +1,27 @@
+/*
+Copyright (c) 2016-2018, 2020, 2022, 2026 The Cytoscape Consortium.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the “Software”), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
 // Simple, internal Object.assign() polyfill for options objects etc.
+
+
 
 module.exports = Object.assign != null ? Object.assign.bind( Object ) : function( tgt, ...srcs ){
   srcs.forEach( src => {

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -1,3 +1,25 @@
+/*
+copyright (c) 2016-2018, 2020, 2022, 2026 the cytoscape consortium.
+
+permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the “software”), to deal in
+the software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the software, and to permit persons to whom the software is furnished to do
+so, subject to the following conditions:
+
+the above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the software.
+
+the software is provided “as is”, without warranty of any kind, express or
+implied, including but not limited to the warranties of merchantability,
+fitness for a particular purpose and noninfringement. in no event shall the
+authors or copyright holders be liable for any claim, damages or other
+liability, whether in an action of contract, tort or otherwise, arising from,
+out of or in connection with the software or the use or other dealings in the
+software.
+*/
+
 let defaults = {
   // dagre algo options, uses default value on undefined
   nodeSep: undefined, // the separation between adjacent nodes in the same rank

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,25 @@
+/*
+copyright (c) 2016-2018, 2020, 2022, 2026 the cytoscape consortium.
+
+permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the “software”), to deal in
+the software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the software, and to permit persons to whom the software is furnished to do
+so, subject to the following conditions:
+
+the above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the software.
+
+the software is provided “as is”, without warranty of any kind, express or
+implied, including but not limited to the warranties of merchantability,
+fitness for a particular purpose and noninfringement. in no event shall the
+authors or copyright holders be liable for any claim, damages or other
+liability, whether in an action of contract, tort or otherwise, arising from,
+out of or in connection with the software or the use or other dealings in the
+software.
+*/
+
 const impl = require('./layout');
 
 // registers the extension on a cytoscape lib ref

--- a/src/layout.js
+++ b/src/layout.js
@@ -1,3 +1,25 @@
+/*
+copyright (c) 2016-2018, 2020, 2022, 2026 the cytoscape consortium.
+
+permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the “software”), to deal in
+the software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the software, and to permit persons to whom the software is furnished to do
+so, subject to the following conditions:
+
+the above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the software.
+
+the software is provided “as is”, without warranty of any kind, express or
+implied, including but not limited to the warranties of merchantability,
+fitness for a particular purpose and noninfringement. in no event shall the
+authors or copyright holders be liable for any claim, damages or other
+liability, whether in an action of contract, tort or otherwise, arising from,
+out of or in connection with the software or the use or other dealings in the
+software.
+*/
+
 const isFunction = function(o){ return typeof o === 'function'; };
 const defaults = require('./defaults');
 const assign = require('./assign');


### PR DESCRIPTION
* [x] Adds a license header to all .js files
* [x] Also adds the year 2026 to the main LICENSE file.

Although officially **not required** by the MIT license itself, most large institutes and companies distribute the LICENSE header over all their source files anyway. This helps avoiding this complex discussion in court altogether: did the copied file come from a (version of) a project with the claimed open-source license, or not? 

The year update is also not required or needed. It just shifts the date when the formal copyright period ends a few years forward. This is different for different countries. No harm in updating it though.