### PR TITLE
enforce Node 24 engine , clean up package scripts and align package.json with ts-refactor modernization plan

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,12 @@
     "dist",
     "src",
     "test",
-    "index.d.ts"
+    "index.d.ts",
+    "REFACTOR-PLAN.md"
   ],
+  "engines": {
+    "node": ">=24.0.0"
+  },
   "author": {
     "name": "Max Franz",
     "email": "maxkfranz@gmail.com"
@@ -33,7 +37,6 @@
     "build:types": "tsc -p tsconfig.types.json",
     "build:js": "rolldown -c rolldown.config.mjs",
     "build": "npm run build:js && npm run build:types",
-    "build:min": "rolldown -c rolldown.config.mjs",
     "build:release": "npm run copyright && npm run build",
     "watch": "rolldown -c rolldown.config.mjs --watch",
     "test": "npm run check && npm run lint && npm run build && npm run test:types && npm run test:node && npm run verify:generated",


### PR DESCRIPTION
This PR applies a few minor cleanups to package.json to fully align it with the ts-refactor modernization goals, ensuring toolchain consistency and clean publishing.

  .  Enforced Node 24 requirement: Added "engines": { "node": ">=24.0.0" } to guarantee developers and CI environments are  
     using the correct baseline toolchain specified in the refactor plan.

  . Cleaned up redundant scripts: Removed the duplicate "build:min" script, as "build:js" using rolldown.config.mjs successfully 
    generates both the readable and minified bundles in a single pass.

  . Included documentation in the published package: Added REFACTOR-PLAN.md to the "files" array so the migration strategy is 
    shipped alongside the NPM package for consuming developers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the supported Node.js version to 24 or newer.
  * Included the refactoring plan in published package files.
  * Removed the obsolete minimal-build command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->